### PR TITLE
community: 投稿一覧の index.json を追加し自動更新する

### DIFF
--- a/.github/workflows/community-index.yaml
+++ b/.github/workflows/community-index.yaml
@@ -1,0 +1,83 @@
+name: community index
+
+# コミュニティ投稿ディレクトリの一覧ファイル (index.json) を自動更新する。
+#
+# なぜ要るか:
+#   RumiCar Simulator (RumiCar-group/RumiCar-Simulator) はこれまで投稿一覧を GitHub API で
+#   取得していたが、未認証の API は IP アドレスあたり 60 回/時。シミュレータは 1 回開くごとに
+#   4 回消費するため、教室のように 1 つの回線を大勢で共有すると数人で使い切ってしまい、
+#   投稿コース・プログラム・車種が「取得できませんでした」になっていた (実測: 15 回開くと枯渇)。
+#   raw.githubusercontent.com にはこの制限が無いので、一覧を静的ファイルとして置けば
+#   API を使わずに済む。シミュレータ v7.4.0 以降は index.json があればそちらを優先し、
+#   無ければ従来どおり API を使う (古いクローンやフォークでも壊れない)。
+#
+# 動き: community 配下が変わった push で一覧を作り直し、差分があるときだけコミットする。
+
+on:
+  push:
+    # 既定ブランチ名を変えたらここも直すこと (無音で止まる)
+    branches: [master]
+    paths:
+      # 生成物 (index.json) 自身は除外する。GITHUB_TOKEN による push は新しい実行を
+      # 起動しないという GitHub の仕様のおかげで今はループしないが、checkout を PAT や
+      # GitHub App のトークンに差し替えた瞬間にループする。仕様だけに頼らず paths でも塞ぐ。
+      - 'courses/community/**'
+      - '!courses/community/index.json'
+      - 'programs/community/**'
+      - '!programs/community/index.json'
+      - 'cars/community/**'
+      - '!cars/community/index.json'
+      - 'tools/gen_community_index.mjs'
+      - '.github/workflows/community-index.yaml'
+  # 取りこぼしたときに手動で流せるようにしておく。
+  # ブランチ制限が無いので、master 以外で実行するとそのブランチにコミットが載る。
+  workflow_dispatch:
+
+permissions:
+  contents: write           # index.json をコミットするため
+
+concurrency:                # 連続 push で同時に走って衝突しないようにする
+  group: community-index
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: 一覧を生成してコミット
+        # 導入時点 (2026-09-04) の確認: master にブランチ保護は無く、リポジトリの既定
+        # ワークフロー権限は write なので、この直 push は通る。将来どちらかが変わると
+        # ここで落ちるが、そのときはワークフローを消すのではなく、生成物を PR にする形へ
+        # 変えるか、手元で `node tools/gen_community_index.mjs .` を実行して普通の PR に
+        # 含める運用にする。
+        #
+        # 競合したら「rebase して直す」のではなく「最新を取り直して生成し直す」。
+        # index.json は生成物なので、マージするより作り直す方が確実に正しくなる
+        # (rebase で衝突を残すと、誤った内容が上流に残って誰も直さない)。
+        run: |
+          set -eu
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          for i in 1 2 3; do
+            git fetch origin "$GITHUB_REF_NAME"
+            git reset --hard "origin/$GITHUB_REF_NAME"
+            node tools/gen_community_index.mjs .
+            # pathspec の意味を git 側に統一する (シェルのグロブは / を跨がないため非対称になる)
+            git add -A -- '*/community/index.json'
+            if git diff --cached --quiet; then
+              echo "変更なし"
+              exit 0
+            fi
+            git commit -m 'community: 投稿一覧 (index.json) を自動更新'
+            if git push; then
+              exit 0
+            fi
+            echo "push が競合した。取り直して生成し直す ($i/3)"
+          done
+          echo "3 回試しても push できなかった" >&2
+          exit 1

--- a/cars/community/index.json
+++ b/cars/community/index.json
@@ -1,0 +1,6 @@
+{
+  "generated": "2026-09-04T10:23:37.472Z",
+  "entries": [
+    "example-community-car.json"
+  ]
+}

--- a/courses/community/index.json
+++ b/courses/community/index.json
@@ -1,0 +1,6 @@
+{
+  "generated": "2026-09-04T10:23:37.468Z",
+  "entries": [
+    "example-community-course.json"
+  ]
+}

--- a/programs/community/index.json
+++ b/programs/community/index.json
@@ -1,0 +1,14 @@
+{
+  "generated": "2026-09-04T10:23:37.472Z",
+  "entries": [
+    "README.md",
+    "blocker-area-denial.ino",
+    "blocker-v2-getahead.ino",
+    "drift-showtime.ino",
+    "drift-striker-experimental.ino",
+    "drift-wall-blocker.ino",
+    "example-balanced-cruiser.ino",
+    "overtaker-passing.ino",
+    "racing-line-speed.ino"
+  ]
+}

--- a/tools/gen_community_index.mjs
+++ b/tools/gen_community_index.mjs
@@ -1,0 +1,64 @@
+/**
+ * コミュニティ投稿ディレクトリの index.json (マニフェスト) を生成する。
+ * 置き場所は上流リポジトリ RumiCar-group/RumiCar の各ディレクトリ直下。
+ *
+ * なぜ要るか: シミュレータは投稿一覧を GitHub API で取っていたが、未認証 API は
+ * IP あたり 60 回/時。教室のように 1 回線を共有すると数人で使い切ってしまう。
+ * raw.githubusercontent.com にはこの制限が無いので、一覧を静的ファイルとして
+ * 置けば API を使わずに済む (シミュレータ v7.4.0 が index.json を優先して読む)。
+ *
+ * 出力形式 (シミュレータ loader.js の listDirCached が読む):
+ *   { "generated": "<ISO8601>", "entries": ["<ファイル名>", ...] }
+ *   ※ 配列だけの ["a.json", ...] も受け付ける。index.json 自身は必ず除外する。
+ *   ※ generated は情報用でシミュレータは読まない。冪等性は entries の一致で判定するので、
+ *     手編集で改行コードやインデントだけが違うファイルは書き直さない (中身は同値)。
+ *
+ * 実行: node gen_community_index.mjs <リポジトリのルート>
+ */
+import { readdirSync, writeFileSync, readFileSync, existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+// 対象は「ファイルが並ぶディレクトリ」だけ。races/ を足してはいけない —
+// シミュレータの公式レース一覧はディレクトリ (eventId) を数えるもので、この生成器は
+// ファイルしか列挙できない。races/index.json を置くと entries:[] = 「大会 0 件・正常」
+// と読めてしまうため、シミュレータ側 (loader.js listDirCached) は dirs 一覧では
+// マニフェストを読まない実装にしてある。両側で二重に塞いでいる。
+// 大会エントリー (races/<id>/entries/) はファイルが並ぶので対象にしてよい。
+const DIRS = ['courses/community', 'programs/community', 'cars/community'];
+
+const root = process.argv[2];
+if (!root) { console.error('使い方: node gen_community_index.mjs <リポジトリのルート>'); process.exit(2); }
+
+let changed = 0;
+let found = 0;
+for (const d of DIRS) {
+  const abs = join(root, d);
+  if (!existsSync(abs) || !statSync(abs).isDirectory()) { console.log(`skip (無い): ${d}`); continue; }
+  found++;
+  // isFile() は lstat 相当なのでシンボリックリンクは false = 一覧に載せない。
+  // raw から素直に取れないものを載せない方が安全なので、これは意図した挙動。
+  // index.json の除外は大小無視 (index.JSON という名前で門をすり抜けさせない)。
+  const entries = readdirSync(abs, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.toLowerCase() !== 'index.json' && !e.name.startsWith('.'))
+    .map((e) => e.name)
+    .sort();                                   // 並びを固定 = 差分が出るのは中身が変わったときだけ
+  const out = join(abs, 'index.json');
+  const body = JSON.stringify({ generated: new Date().toISOString(), entries }, null, 2) + '\n';
+  // entries が同じなら書かない (generated だけが動く無意味なコミットを避ける)
+  let prev = null;
+  try { prev = JSON.parse(readFileSync(out, 'utf8')); } catch (e) { prev = null; }
+  if (prev && Array.isArray(prev.entries) && JSON.stringify(prev.entries) === JSON.stringify(entries)) {
+    console.log(`変更なし: ${d}/index.json (${entries.length} 件)`);
+    continue;
+  }
+  writeFileSync(out, body);
+  changed++;
+  console.log(`書き出し: ${d}/index.json (${entries.length} 件)`);
+}
+// 1 つも見つからないのは「投稿が無い」ではなく「実行場所が違う」。
+// 黙って成功すると、CI が緑のまま一覧が更新されない状態が続くので落とす。
+if (found === 0) {
+  console.error(`対象ディレクトリが 1 つも見つからない (root=${root})。リポジトリのルートを渡すこと`);
+  process.exit(1);
+}
+console.log(changed ? `更新 ${changed} 件` : '更新なし');


### PR DESCRIPTION
投稿一覧を静的な `index.json` として持ち、シミュレータが GitHub API を使わずに読めるようにします。既存ファイルの変更はありません（新規追加 5 ファイルのみ）。

## 追加するファイル

| パス | 中身 |
|---|---|
| `tools/gen_community_index.mjs` | 一覧生成器（Node 標準ライブラリのみ・依存なし） |
| `.github/workflows/community-index.yaml` | community 配下の push で一覧を作り直す |
| `courses/community/index.json` | 1 件 |
| `programs/community/index.json` | 9 件 |
| `cars/community/index.json` | 1 件 |

## なぜ

RumiCar Simulator（[RumiCar-group/RumiCar-Simulator](https://github.com/RumiCar-group/RumiCar-Simulator)）は投稿一覧を GitHub contents API で取得しています。未認証の API は **IP アドレスあたり 60 回/時**で、1 回起動するごとに 4 回消費するため、実測では **15 回開いた時点で上限**に達します。教室のように 1 本の回線を 10 人で共有する場では数回ずつ開いただけで打ち止めになり、投稿コース・プログラム・車種が「取得できませんでした」になります（走行自体は止まらない設計です）。

`raw.githubusercontent.com` にはこの制限がありません（応答にレート制限ヘッダが存在しないことを実測で確認）。一覧を静的な `index.json` として置けば、シミュレータは API を使わずに投稿一覧を読めます。

なお ETag による条件付き取得も試しましたが、**304（変更なし）でも 1 回消費する**ことを実測で確認したため（残り 57→56→55）、採用していません。

## 安全性・互換性

- **既存の動作を変えません。** `index.json` は新規ファイルで、既存のコース/プログラム/車種は 1 バイトも変更していません。
- **シミュレータ側は v7.4.0 で対応済み**です（`RumiCar-group/RumiCar-Simulator` の `ab75d43`）。`index.json` があればそちらを読み、無ければ従来どおり API を使うので、古いクローンやフォークでも壊れません。
- **`index.json` 自身は一覧に出しません。** v7.4.0 は、マニフェスト経路と API 経路の**両方**で除外します。
- **順序の注意**: シミュレータ **v7.3.0 以前**は API 経路しか持たず、`index.json` の除外もありません。そのクライアントでは `courses/community/index.json` が「index」という名前の空コース（壁なし 3m×2m）としてメニューに出ます。www.rumicar.com/simulator/ は既に v7.4.0 なので影響しませんが、**v7.3.0 のまま自前ホストしているフォークがあれば先に更新をお願いします**。投稿車種と投稿プログラムには元々出ません。
- **`races/` は対象外**です。公式レース一覧はディレクトリを数えるもので、この生成器はファイルしか列挙しません。誤って追加されないよう、生成器のコメントとシミュレータ側の実装（ディレクトリ一覧ではマニフェストを読まない）の両方で塞いであります。

## ワークフローについて

`permissions: contents: write` で `index.json` を直接コミットします。導入時点で
`master` にブランチ保護は無く、リポジトリの既定ワークフロー権限は `write` であることを
確認済みです。将来どちらかが変わった場合は、生成物を PR にする形へ変えるか、手元で
`node tools/gen_community_index.mjs .` を実行して普通の PR に含める運用にできます。
`index.json` が無くてもシミュレータは API へ落ちて動くので、更新が止まることはあっても
壊れることはありません。

- 生成物（`*/community/index.json`）自身は `paths` の否定パターンで除外しており、自分の push で自分が起動することはありません。
- push が競合したときは、rebase でマージするのではなく **最新を取り直して生成し直します**（生成物なので作り直す方が確実に正しくなります）。
- fork からの PR では起動しません（`pull_request` トリガを持たないため）。

## 検証したこと

- 生成器は冪等（2 回目は「変更なし」で書き込まない）。このリポジトリのクローンで実行して確認。ルートを取り違えたときは無音で成功せず exit 1 で落ちます。
- **PR に入る index.json の実バイト列**をシミュレータの `loader.js` に読ませ、courses 1 件 / programs 8 件（README.md は拡張子で除外）/ cars 1 件を **API 呼び出し 0 回**で取得できることを確認。
- シミュレータ側は常設ゲート 26 項目で機械確認。守っている行を 1 つずつ壊すと必ず赤くなることも変異テストで確認済み（`index.json` 除外・URL エンコード・区切り文字の門・キャッシュ検証・ディレクトリ一覧でのマニフェスト禁止・403 非キャッシュの 6 種）。
- 実ブラウザ（Playwright）で本番を 2 回開き、再訪問時の API 消費が 4 回 → **0 回**になることを実測。
